### PR TITLE
Add Measure for recording bit widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ alias ardb="platformio -f -c atom run"
 alias ardu="platformio -f -c atom run -t upload"
 alias ardm="platformio serialports monitor"
 ```
+
+## Development
+
+```sh
+git clone https://github.com/jch/gm-radio
+rake
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/*_test.rb"]
+  t.verbose = true
+end
+
+task :default => :test

--- a/lib/measure.rb
+++ b/lib/measure.rb
@@ -1,0 +1,48 @@
+class Measure
+  def initialize(input:, output: $stdout)
+    @input = input
+    @output = output
+  end
+
+  # For a table given on stdin:
+  #
+  # state, time (header not included)
+  # 1 0
+  # 1 5
+  # 1 7
+  # 0 10
+  # 0 20
+  # 1 33
+  # 1 40
+  #
+  # Output a table of for the duration of each state:
+  #
+  # state, time
+  # 1 10 (pull high for 5us)
+  # 0 23 (pull low for 23us 33 - 10)
+  # 1 7 (pull high for 7us 40 - 33)
+  def process!
+    # initialize values
+    previous_state, previous_time = @input.readline.split(" ")
+
+    until @input.eof?
+      state, time = @input.readline.split(" ")
+
+      # for the last state, always print the duration even if it hasn't flipped
+      if @input.eof?
+        duration = time.to_i - previous_time.to_i
+        @output.puts "#{previous_state} #{duration}"
+        break
+      else
+        # didn't flip in state, look ahead
+        next if state == previous_state
+
+        duration = time.to_i - previous_time.to_i
+        @output.puts "#{previous_state} #{duration}"
+
+        previous_state, previous_time = state, time
+      end
+    end
+  rescue EOFError => e
+  end
+end

--- a/script/measure
+++ b/script/measure
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative "../lib/measure"
+
+Measure.process!(ARGF)

--- a/test/measure_test.rb
+++ b/test/measure_test.rb
@@ -1,0 +1,40 @@
+require "stringio"
+require_relative "../lib/measure"
+require_relative "test_helper"
+
+class MeasureTest < Minitest::Test
+  def setup
+    @output = StringIO.new
+  end
+
+  def test_process_empty_outputs_nothing
+    input = StringIO.new ""
+    measure = Measure.new(input: input, output: @output)
+    measure.process!
+    assert_equal "", @output.read
+  end
+
+  def test_process_single_line_outputs_nothing
+    input = StringIO.new "1 1234\n"
+    measure = Measure.new(input: input, output: @output)
+    measure.process!
+    @output.rewind
+    assert_equal "", @output.read
+  end
+
+  def test_process_multi_line_outputs_states_with_time
+    input = StringIO.new "1 10\n1 20\n1 30\n0 40\n0 50"
+    measure = Measure.new(input: input, output: @output)
+    measure.process!
+    @output.rewind
+    assert_equal "1 30\n0 10\n", @output.read
+  end
+
+  def test_process_multi_line_dangling_state_outputs_states_with_time
+    input = StringIO.new "1 10\n0 20"
+    measure = Measure.new(input: input, output: @output)
+    measure.process!
+    @output.rewind
+    assert_equal "1 10\n", @output.read
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,1 @@
+require "minitest/autorun"


### PR DESCRIPTION
Ruby script for measuring bit widths:

For a table given on stdin:

```
state, time (header not included)
1 0
1 5
1 7
0 10
0 20
1 33
1 40
```

Output a table of for the duration of each state:

```
state, time
1 10 (pull high for 10us)
0 23 (pull low for 23us 33 - 10)
1 7 (pull high for 7us 40 - 33)
```

Still need to write the arduino script to generate the first table, eventually want to run this with:

``` sh
$ platformio serialports monitor | script/measure
```

cc @jonmagic
